### PR TITLE
Add reverse option

### DIFF
--- a/bin/swsync
+++ b/bin/swsync
@@ -34,7 +34,15 @@ class Main(object):
             dest='log_level',
             default='info',
             help='Number of containers to distribute objects among')
+        parser.add_option(
+            '-R', '--reverse',
+            action="store_true",
+            dest='reverse',
+            default=False,
+            help='Traverse container list forward or reversed')
         self.options, args = parser.parse_args()
+        if self.options:
+            swsync.utils.REVERSE = self.options.reverse
         if args:
             conf = swsync.utils.parse_ini(args[0])
         else:

--- a/swsync/accounts.py
+++ b/swsync/accounts.py
@@ -137,7 +137,11 @@ class Accounts(object):
                 # let's pass it on for the next pass
                 return
 
-        for container in orig_containers:
+        container_list = iter(orig_containers)
+        if swsync.utils.REVERSE:
+            container_list = reversed(orig_containers)
+
+        for container in container_list:
             logging.info("Syncronizing container %s: %s",
                          container['name'], container)
             dt1 = datetime.datetime.fromtimestamp(time.time())

--- a/swsync/utils.py
+++ b/swsync/utils.py
@@ -24,6 +24,7 @@ curdir = os.path.abspath(os.path.dirname(__file__))
 INIFILE = os.path.abspath(os.path.join(curdir, '..', 'etc', "config.ini"))
 SAMPLE_INIFILE = os.path.abspath(os.path.join(curdir, '..',
                                               'etc', "config.ini-sample"))
+REVERSE = False
 
 
 class ConfigurationError(Exception):
@@ -55,7 +56,7 @@ def parse_ini(inicfg=None):
     elif inicfg is None and os.path.exists(INIFILE):
         fp = open(INIFILE)
     else:
-        raise ConfigurationError("Cannot found inicfg")
+        raise ConfigurationError("Cannot find inicfg")
 
     config = ConfigParser.RawConfigParser()
     config.readfp(fp)


### PR DESCRIPTION
We sync really large groups of containers, which can take longer than 24 hours to traverse. By running forward and reverse traversals at the same time, we can make sure that the end of the list gets work too.
